### PR TITLE
Use ETS instead of Mnesia

### DIFF
--- a/include/phonenumbers.hrl
+++ b/include/phonenumbers.hrl
@@ -7,7 +7,7 @@
 -define(FILE_PHONE_PHONE_FORMATS, "PhoneNumberMetadata.xml").
 -define(REGEXP_PHONE, <<"^\\+[0-9]{8,15}$">>).
 
--record(countryphones, {code, code_rules = []}).
+-define(ETS_TABLE, libphonenumber_erlang_registry).
 
 -record(phone_pattern, {
   code = undefined,
@@ -23,3 +23,9 @@
   part}).
 
 -record(code_set, {id, lengths = [], name, pattern, metadata}).
+
+-record(countryphones, {
+  code :: binary(),
+  code_rules = [] :: list(#code_set{})
+}).
+

--- a/src/libphonenumbers.erl
+++ b/src/libphonenumbers.erl
@@ -65,7 +65,7 @@ rules_for_codepairs([], #{errors := Errors} = ValidationLog) ->
   ValidationLog#{valid => false, errors => [#{"NO PAIRS" => "Finished"} | Errors]};
 
 rules_for_codepairs([{Code, Phone} | Pairs], ValidationLog) ->
-  Rules = mnesia:dirty_read(countryphones, Code),
+  Rules = ets:lookup(?ETS_TABLE, Code),
   #{valid := IsValid, errors := ResErrors} = ValidationResult = rules_for_code(Rules, ValidationLog, {Code, Phone}),
   if IsValid ->
     ValidationResult;

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,4 @@
+#!/usr/bin/env bash
 make
-MNESIADIR='"MnesiaLibPhoneNumber"'
-echo libphonenumber_erlang run with $MNESIADIR
-exec erl -pa ebin/ deps/*/ebin -s libphonenumber_erlang_app -name libphonenumber_erlang@localhost \
-	-mnesia dir $MNESIADIR
+echo libphonenumber_erlang starting
+exec erl -pa ./ebin ./src -name libphonenumber_erlang@localhost -eval "application:start(tools), application:start(libphonenumber_erlang)"


### PR DESCRIPTION
Actually the switch to ETS (with regards of the conversation we had in #16 ) is pretty simple and easy, so I did it.  As far as I tested, it works exactly as before.

I think this change is worth it as it will ease adoption and reading the xml on every startup is actually no big deal IMO. It's practically instant.